### PR TITLE
Starter project fails with current mothertongues

### DIFF
--- a/config.mtd.json
+++ b/config.mtd.json
@@ -106,8 +106,8 @@
             "skip_header": false,
             "transducers": [],
             "targets": {
-                "word": 0,
-                "definition": 1
+                "word": "0",
+                "definition": "1"
             }
         },
         "resource": "data.csv"


### PR DESCRIPTION
The manifest validation fails because targets are required to be strings:

```
ValidationError: 3 validation errors for MTDConfiguration
data.function-after[data_is_valid(), DataSource]
  Input should be a valid dictionary or instance of DataSource [type=model_type, input_value=[{'manifest': {'file_type...mtd-starter/data.csv')}], input_type=list]
    For further information visit https://errors.pydantic.dev/2.6/v/model_type
data.list[function-after[data_is_valid(), DataSource]].0.manifest.targets.word
  Input should be a valid string [type=string_type, input_value=0, input_type=int]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
data.list[function-after[data_is_valid(), DataSource]].0.manifest.targets.definition
  Input should be a valid string [type=string_type, input_value=1, input_type=int]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
```

In addition, they *can't* be `int`s because the parser code uses `isinstance(v, str)` to determine if the target is a scalar value.

It seems reasonable to just use strings, I guess, so update the starter project so that it actually runs.  We should also support CSVs with named columns in the header since that is a pretty common way of formatting them.